### PR TITLE
Добавил ссылку на менеджера в футере

### DIFF
--- a/backend/design/html/index.tpl
+++ b/backend/design/html/index.tpl
@@ -343,7 +343,7 @@
                 </div>
                 <footer id="footer" class="">
                     <div class="col-md-12 font_12 text_white">
-                        <a href="https://okay-cms.com">OkayCMS </a> &copy; {$smarty.now|date_format:"%Y"} v.{$config->version} | {$btr->index_logged|escape} <a href="index.php?controller=ManagerAdmin&id={$manager->id}">{$manager->login|escape}</a>
+                        <a href="https://okay-cms.com">OkayCMS </a> &copy; {$smarty.now|date_format:"%Y"} v.{$config->version} | {$btr->index_logged|escape} <a href="index.php?controller=ManagerAdmin&id={$manager->id}">{$manager->login|escape}</a> (<a href="{$rootUrl}?logout">{$btr->index_exit|escape}</a>)
                         <div class="float-md-right">
                             <a href='index.php?controller=LicenseAdmin' class="text_white">{$btr->license_text|escape} </a>
                             ,

--- a/backend/design/html/index.tpl
+++ b/backend/design/html/index.tpl
@@ -343,7 +343,7 @@
                 </div>
                 <footer id="footer" class="">
                     <div class="col-md-12 font_12 text_white">
-                        <a href="https://okay-cms.com">OkayCMS </a> &copy; {$smarty.now|date_format:"%Y"} v.{$config->version} | {$btr->index_logged|escape}  {$manager->login|escape}
+                        <a href="https://okay-cms.com">OkayCMS </a> &copy; {$smarty.now|date_format:"%Y"} v.{$config->version} | {$btr->index_logged|escape} <a href="index.php?controller=ManagerAdmin&id={$manager->id}">{$manager->login|escape}</a>
                         <div class="float-md-right">
                             <a href='index.php?controller=LicenseAdmin' class="text_white">{$btr->license_text|escape} </a>
                             ,


### PR DESCRIPTION
Можно быстрее перейти к редактированию админа, или выйти.

![manager](https://user-images.githubusercontent.com/12523676/108361845-0d175280-7204-11eb-8d30-7351fb5b0208.png)

p.s. В будущем, имеет смысл как-то обозначать **пользователя в шапке сверху**, т.к. если несколько аккаунтов, то как узнать под каким я зашел в админку? А скроллить вниз не удобно.
Можно сделать, например:

![manager_2](https://user-images.githubusercontent.com/12523676/108362777-34baea80-7205-11eb-8490-59c9a15b56a6.png)
